### PR TITLE
Removed commas for php <=7.2 support

### DIFF
--- a/src/Exporter/FailedJobsPerHour.php
+++ b/src/Exporter/FailedJobsPerHour.php
@@ -20,7 +20,7 @@ class FailedJobsPerHour implements Exporter
         $this->gauge = $prometheusExporter->registerGauge(
             config('horizon-exporter.namespace'),
             'horizon_failed_jobs',
-            'The number of recently failed jobs',
+            'The number of recently failed jobs'
         );
     }
 

--- a/src/Exporter/HorizonStatus.php
+++ b/src/Exporter/HorizonStatus.php
@@ -20,7 +20,7 @@ class HorizonStatus implements Exporter
         $this->gauge = $prometheusExporter->registerGauge(
             config('horizon-exporter.namespace'),
             'horizon_status',
-            'The status of Horizon, -1 = inactive, 0 = paused, 1 = running',
+            'The status of Horizon, -1 = inactive, 0 = paused, 1 = running'
         );
     }
 


### PR DESCRIPTION
Thanks for this package, it is very useful for me. 
But my servers use php 7.2, and i have errors for this commas.