### PR TITLE
Use CIDR mask in IP whitelist check

### DIFF
--- a/src/Http/Middleware/IPWhitelistingMiddleware.php
+++ b/src/Http/Middleware/IPWhitelistingMiddleware.php
@@ -5,6 +5,7 @@ namespace LKDevelopment\HorizonPrometheusExporter\Http\Middleware;
 
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
+use Symfony\Component\HttpFoundation\IpUtils;
 
 class IPWhitelistingMiddleware
 {
@@ -12,7 +13,7 @@ class IPWhitelistingMiddleware
     {
         if (!empty(config('horizon-exporter.ip_whitelist'))) {
             $clientIp = $request->ip();
-            if (in_array($clientIp, config('horizon-exporter.ip_whitelist'))) {
+            if (IpUtils::checkIp($clientIp, config('horizon-exporter.ip_whitelist'))) {
                 return $next($request);
             } else {
                 abort(403);

--- a/tests/Http/Middleware/IPWhitelistingMiddlewareTest.php
+++ b/tests/Http/Middleware/IPWhitelistingMiddlewareTest.php
@@ -38,6 +38,14 @@ class IPWhitelistingMiddlewareTest extends TestCase
             [
                 "127.0.0.2",
                 Response::HTTP_FORBIDDEN
+            ],
+            [
+                "10.0.0.1",
+                Response::HTTP_OK
+            ],
+            [
+                "10.0.1.1",
+                Response::HTTP_FORBIDDEN
             ]
         ];
     }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -8,6 +8,6 @@ class TestCase extends \Orchestra\Testbench\TestCase
     protected function getEnvironmentSetUp($app)
     {
         $app['config']->set('horizon-exporter.exporters', [NoopExporter::class]);
-        $app['config']->set('horizon-exporter.ip_whitelist', ["127.0.0.1"]);
+        $app['config']->set('horizon-exporter.ip_whitelist', ["127.0.0.1", "10.0.0.0/24"]);
     }
 }


### PR DESCRIPTION
This PR uses package the IpUtils::checkIP() function from from Symfony\HttpFoundation to check for CIDR mask instead of specific IP addresses for whitelisting. Should work the same with both just specifying the IP address and using CIDR mask for the whitelist.