### PR TITLE
Fixed TypeError in IPWhitelistingMiddleware

### DIFF
--- a/src/Http/Middleware/IPWhitelistingMiddleware.php
+++ b/src/Http/Middleware/IPWhitelistingMiddleware.php
@@ -9,7 +9,7 @@ use Symfony\Component\HttpFoundation\IpUtils;
 
 class IPWhitelistingMiddleware
 {
-    public function handle(Request $request, \Closure $next): Response
+    public function handle(Request $request, \Closure $next)
     {
         if (!empty(config('horizon-exporter.ip_whitelist'))) {
             $clientIp = $request->ip();


### PR DESCRIPTION
The mistake:

Return value of LKDevelopment\HorizonPrometheusExporter\Http\Middleware\IPWhitelistingMiddleware::handle() must be an instance of Illuminate\Http\Response, instance of Illuminate\Http\RedirectResponse returned