### PR TITLE
Use getOrRegisterGauge to make  usage in Swoole possible

### DIFF
--- a/src/Exporter/CurrentMasterSupervisors.php
+++ b/src/Exporter/CurrentMasterSupervisors.php
@@ -14,7 +14,7 @@ class CurrentMasterSupervisors implements Exporter
 
     public function metrics(CollectorRegistry $collectorRegistry)
     {
-		$this->gauge = $collectorRegistry->registerGauge(
+		$this->gauge = $collectorRegistry->getOrRegisterGauge(
 			config('horizon-exporter.namespace'),
 			'horizon_current_mastersupervisors',
 			'Number of mastersupervisors'

--- a/src/Exporter/CurrentProccesesPerQueue.php
+++ b/src/Exporter/CurrentProccesesPerQueue.php
@@ -12,7 +12,7 @@ class CurrentProccesesPerQueue implements Exporter
     protected $gauge;
     public function metrics(CollectorRegistry $collectorRegistry)
     {
-        $this->gauge = $collectorRegistry->registerGauge(
+        $this->gauge = $collectorRegistry->getOrRegisterGauge(
             config('horizon-exporter.namespace'),
             'horizon_current_processes',
             'Current processes of all queues',

--- a/src/Exporter/CurrentWorkload.php
+++ b/src/Exporter/CurrentWorkload.php
@@ -13,7 +13,7 @@ class CurrentWorkload implements Exporter
     protected $gauge;
     public function metrics(CollectorRegistry $collectorRegistry)
     {
-        $this->gauge = $collectorRegistry->registerGauge(
+        $this->gauge = $collectorRegistry->getOrRegisterGauge(
             config('horizon-exporter.namespace'),
             'horizon_current_workload',
             'Current workload of all queues',

--- a/src/Exporter/FailedJobsPerHour.php
+++ b/src/Exporter/FailedJobsPerHour.php
@@ -14,7 +14,7 @@ class FailedJobsPerHour implements Exporter
 
     public function metrics(CollectorRegistry $collectorRegistry)
     {
-        $this->gauge = $collectorRegistry->registerGauge(
+        $this->gauge = $collectorRegistry->getOrRegisterGauge(
             config('horizon-exporter.namespace'),
             'horizon_failed_jobs',
             'The number of recently failed jobs'

--- a/src/Exporter/HorizonStatus.php
+++ b/src/Exporter/HorizonStatus.php
@@ -14,7 +14,7 @@ class HorizonStatus implements Exporter
 
     public function metrics(CollectorRegistry $collectorRegistry)
     {
-        $this->gauge = $collectorRegistry->registerGauge(
+        $this->gauge = $collectorRegistry->getOrRegisterGauge(
             config('horizon-exporter.namespace'),
             'horizon_status',
             'The status of Horizon, -1 = inactive, 0 = paused, 1 = running'

--- a/src/Exporter/JobsPerMinute.php
+++ b/src/Exporter/JobsPerMinute.php
@@ -13,7 +13,7 @@ class JobsPerMinute implements Exporter
     protected $gauge;
     public function metrics(CollectorRegistry $collectorRegistry)
     {
-        $this->gauge = $collectorRegistry->registerGauge(
+        $this->gauge = $collectorRegistry->getOrRegisterGauge(
             config('horizon-exporter.namespace'),
             'horizon_jobs_per_minute',
             'The number of jobs per minute'

--- a/src/Exporter/RecentJobs.php
+++ b/src/Exporter/RecentJobs.php
@@ -14,7 +14,7 @@ class RecentJobs implements Exporter
 
     public function metrics(CollectorRegistry $collectorRegistry)
     {
-        $this->gauge = $collectorRegistry->registerGauge(
+        $this->gauge = $collectorRegistry->getOrRegisterGauge(
             config('horizon-exporter.namespace'),
             'horizon_recent_jobs',
             'The number of recent jobs'


### PR DESCRIPTION
When you run your code in swoole, coolector can't create. I got exception  "Prometheus\Exception\MetricsRegistrationException: Metric already registered". 
phprom has method getOrRegisterGauge, it's better then registerGauge