### PR TITLE
Use split_queues when available

### DIFF
--- a/src/Exporter/CurrentWorkload.php
+++ b/src/Exporter/CurrentWorkload.php
@@ -27,6 +27,14 @@ class CurrentWorkload implements Exporter
         $workloads = collect($workloadRepository->get())->sortBy('name')->values();
 
         $workloads->each(function ($workload) {
+            if ($workload['split_queues']) {
+                $workload['split_queues']->each(function ($queue) {
+                    $this->gauge->set($queue['length'], [$queue['name']]);
+                });
+
+                return;
+            }
+
             $this->gauge->set($workload['length'], [$workload['name']]);
         });
     }


### PR DESCRIPTION
This will use the split_queues that are returned from Horizon when you have a worker processing multiple queues. For example "priority,general" will return the correct numbers for each queue instead of a sum of both.