### PR TITLE
Add more type hinting to the classes and fix a typo in the CurrentProcessesPerQueue class name

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -18,7 +18,7 @@ return [
         \LKDevelopment\HorizonPrometheusExporter\Exporter\CurrentMasterSupervisors::class,
         \LKDevelopment\HorizonPrometheusExporter\Exporter\JobsPerMinute::class,
         \LKDevelopment\HorizonPrometheusExporter\Exporter\CurrentWorkload::class,
-        \LKDevelopment\HorizonPrometheusExporter\Exporter\CurrentProccesesPerQueue::class,
+        \LKDevelopment\HorizonPrometheusExporter\Exporter\CurrentProcessesPerQueue::class,
         \LKDevelopment\HorizonPrometheusExporter\Exporter\FailedJobsPerHour::class,
         \LKDevelopment\HorizonPrometheusExporter\Exporter\HorizonStatus::class,
         \LKDevelopment\HorizonPrometheusExporter\Exporter\RecentJobs::class

--- a/src/Contracts/Exporter.php
+++ b/src/Contracts/Exporter.php
@@ -17,7 +17,7 @@ interface Exporter
      * @param CollectorRegistry $collectorRegistry
      * @void
      */
-    public function metrics(CollectorRegistry $collectorRegistry);
+    public function metrics(CollectorRegistry $collectorRegistry): void;
 
     /**
      * The collect method is called from the Exporter when he collects the data.
@@ -25,5 +25,5 @@ interface Exporter
      * collection within this method.
      * @void
      */
-    public function collect();
+    public function collect(): void;
 }

--- a/src/Exporter/CurrentMasterSupervisors.php
+++ b/src/Exporter/CurrentMasterSupervisors.php
@@ -7,12 +7,13 @@ namespace LKDevelopment\HorizonPrometheusExporter\Exporter;
 use Laravel\Horizon\Contracts\MasterSupervisorRepository;
 use LKDevelopment\HorizonPrometheusExporter\Contracts\Exporter;
 use Prometheus\CollectorRegistry;
+use Prometheus\Gauge;
 
 class CurrentMasterSupervisors implements Exporter
 {
-    protected $gauge;
+    protected Gauge $gauge;
 
-    public function metrics(CollectorRegistry $collectorRegistry)
+    public function metrics(CollectorRegistry $collectorRegistry): void
     {
 		$this->gauge = $collectorRegistry->getOrRegisterGauge(
 			config('horizon-exporter.namespace'),
@@ -21,9 +22,8 @@ class CurrentMasterSupervisors implements Exporter
 		);
     }
 
-    public function collect()
+    public function collect(): void
     {
-
 		$number = count(app(MasterSupervisorRepository::class)->all());
 
 		$this->gauge->set($number);

--- a/src/Exporter/CurrentProcessesPerQueue.php
+++ b/src/Exporter/CurrentProcessesPerQueue.php
@@ -6,11 +6,13 @@ namespace LKDevelopment\HorizonPrometheusExporter\Exporter;
 use Laravel\Horizon\Contracts\WorkloadRepository;
 use LKDevelopment\HorizonPrometheusExporter\Contracts\Exporter;
 use Prometheus\CollectorRegistry;
+use Prometheus\Gauge;
 
-class CurrentProccesesPerQueue implements Exporter
+class CurrentProcessesPerQueue implements Exporter
 {
-    protected $gauge;
-    public function metrics(CollectorRegistry $collectorRegistry)
+    protected Gauge $gauge;
+
+    public function metrics(CollectorRegistry $collectorRegistry): void
     {
         $this->gauge = $collectorRegistry->getOrRegisterGauge(
             config('horizon-exporter.namespace'),
@@ -20,7 +22,7 @@ class CurrentProccesesPerQueue implements Exporter
         );
     }
 
-    public function collect()
+    public function collect(): void
     {
         $workloadRepository = app(WorkloadRepository::class);
         $workloads = collect($workloadRepository->get())->sortBy('name')->values();

--- a/src/Exporter/CurrentWorkload.php
+++ b/src/Exporter/CurrentWorkload.php
@@ -7,11 +7,13 @@ namespace LKDevelopment\HorizonPrometheusExporter\Exporter;
 use Laravel\Horizon\Contracts\WorkloadRepository;
 use LKDevelopment\HorizonPrometheusExporter\Contracts\Exporter;
 use Prometheus\CollectorRegistry;
+use Prometheus\Gauge;
 
 class CurrentWorkload implements Exporter
 {
-    protected $gauge;
-    public function metrics(CollectorRegistry $collectorRegistry)
+    protected Gauge $gauge;
+
+    public function metrics(CollectorRegistry $collectorRegistry): void
     {
         $this->gauge = $collectorRegistry->getOrRegisterGauge(
             config('horizon-exporter.namespace'),
@@ -21,7 +23,7 @@ class CurrentWorkload implements Exporter
         );
     }
 
-    public function collect()
+    public function collect(): void
     {
         $workloadRepository = app(WorkloadRepository::class);
         $workloads = collect($workloadRepository->get())->sortBy('name')->values();

--- a/src/Exporter/FailedJobsPerHour.php
+++ b/src/Exporter/FailedJobsPerHour.php
@@ -7,12 +7,13 @@ namespace LKDevelopment\HorizonPrometheusExporter\Exporter;
 use Laravel\Horizon\Contracts\JobRepository;
 use LKDevelopment\HorizonPrometheusExporter\Contracts\Exporter;
 use Prometheus\CollectorRegistry;
+use Prometheus\Gauge;
 
 class FailedJobsPerHour implements Exporter
 {
-    protected $gauge;
+    protected Gauge $gauge;
 
-    public function metrics(CollectorRegistry $collectorRegistry)
+    public function metrics(CollectorRegistry $collectorRegistry): void
     {
         $this->gauge = $collectorRegistry->getOrRegisterGauge(
             config('horizon-exporter.namespace'),
@@ -21,7 +22,7 @@ class FailedJobsPerHour implements Exporter
         );
     }
 
-    public function collect()
+    public function collect(): void
     {
         $this->gauge->set(app(JobRepository::class)->countRecentlyFailed());
     }

--- a/src/Exporter/HorizonStatus.php
+++ b/src/Exporter/HorizonStatus.php
@@ -7,12 +7,13 @@ namespace LKDevelopment\HorizonPrometheusExporter\Exporter;
 use Laravel\Horizon\Contracts\MasterSupervisorRepository;
 use LKDevelopment\HorizonPrometheusExporter\Contracts\Exporter;
 use Prometheus\CollectorRegistry;
+use Prometheus\Gauge;
 
 class HorizonStatus implements Exporter
 {
-    protected $gauge;
+    protected Gauge $gauge;
 
-    public function metrics(CollectorRegistry $collectorRegistry)
+    public function metrics(CollectorRegistry $collectorRegistry): void
     {
         $this->gauge = $collectorRegistry->getOrRegisterGauge(
             config('horizon-exporter.namespace'),
@@ -21,7 +22,7 @@ class HorizonStatus implements Exporter
         );
     }
 
-    public function collect()
+    public function collect(): void
     {
         $status = -1;
         if ($masters = app(MasterSupervisorRepository::class)->all()) {
@@ -30,6 +31,5 @@ class HorizonStatus implements Exporter
             }) ? 0 : 1;
         }
         $this->gauge->set($status);
-
     }
 }

--- a/src/Exporter/JobsPerMinute.php
+++ b/src/Exporter/JobsPerMinute.php
@@ -7,11 +7,13 @@ namespace LKDevelopment\HorizonPrometheusExporter\Exporter;
 use Laravel\Horizon\Contracts\MetricsRepository;
 use LKDevelopment\HorizonPrometheusExporter\Contracts\Exporter;
 use Prometheus\CollectorRegistry;
+use Prometheus\Gauge;
 
 class JobsPerMinute implements Exporter
 {
-    protected $gauge;
-    public function metrics(CollectorRegistry $collectorRegistry)
+    protected Gauge $gauge;
+
+    public function metrics(CollectorRegistry $collectorRegistry): void
     {
         $this->gauge = $collectorRegistry->getOrRegisterGauge(
             config('horizon-exporter.namespace'),
@@ -20,7 +22,7 @@ class JobsPerMinute implements Exporter
         );
     }
 
-    public function collect()
+    public function collect(): void
     {
         $this->gauge->set(app(MetricsRepository::class)->jobsProcessedPerMinute());
     }

--- a/src/Exporter/RecentJobs.php
+++ b/src/Exporter/RecentJobs.php
@@ -7,12 +7,13 @@ namespace LKDevelopment\HorizonPrometheusExporter\Exporter;
 use Laravel\Horizon\Contracts\JobRepository;
 use LKDevelopment\HorizonPrometheusExporter\Contracts\Exporter;
 use Prometheus\CollectorRegistry;
+use Prometheus\Gauge;
 
 class RecentJobs implements Exporter
 {
-    protected $gauge;
+    protected Gauge $gauge;
 
-    public function metrics(CollectorRegistry $collectorRegistry)
+    public function metrics(CollectorRegistry $collectorRegistry): void
     {
         $this->gauge = $collectorRegistry->getOrRegisterGauge(
             config('horizon-exporter.namespace'),
@@ -21,7 +22,7 @@ class RecentJobs implements Exporter
         );
     }
 
-    public function collect()
+    public function collect(): void
     {
         $this->gauge->set(app(JobRepository::class)->countRecent());
     }

--- a/src/HorizonPrometheusExporterServiceProvider.php
+++ b/src/HorizonPrometheusExporterServiceProvider.php
@@ -10,7 +10,7 @@ class HorizonPrometheusExporterServiceProvider extends ServiceProvider
     /**
      * Bootstrap the application services.
      */
-    public function boot()
+    public function boot(): void
     {
         if ($this->app->runningInConsole()) {
             $this->publishes([
@@ -25,12 +25,12 @@ class HorizonPrometheusExporterServiceProvider extends ServiceProvider
     /**
      * Register the application services.
      */
-    public function register()
+    public function register(): void
     {
         $this->mergeConfigFrom(__DIR__ . '/../config/config.php', 'horizon-exporter');
     }
 
-    protected function routes()
+    protected function routes(): void
     {
         if ($this->app->routesAreCached()) {
             return;

--- a/src/Repository/ExporterRepository.php
+++ b/src/Repository/ExporterRepository.php
@@ -42,7 +42,7 @@ class ExporterRepository
     /**
      * @param CollectorRegistry $collectorRegistry
      */
-    public static function setRegistry(CollectorRegistry $collectorRegistry)
+    public static function setRegistry(CollectorRegistry $collectorRegistry): void
     {
         self::$registry = $collectorRegistry;
     }

--- a/tests/Util/NoopExporter.php
+++ b/tests/Util/NoopExporter.php
@@ -16,11 +16,11 @@ class NoopExporter implements \LKDevelopment\HorizonPrometheusExporter\Contracts
     /**
      * @var Counter
      */
-    protected $counter;
+    protected Counter $counter;
     /**
      * @inheritDoc
      */
-    public function metrics(CollectorRegistry $collectorRegistry)
+    public function metrics(CollectorRegistry $collectorRegistry): void
     {
         $this->counter = $collectorRegistry->getOrRegisterCounter(
             "app",
@@ -33,7 +33,7 @@ class NoopExporter implements \LKDevelopment\HorizonPrometheusExporter\Contracts
     /**
      * @inheritDoc
      */
-    public function collect()
+    public function collect(): void
     {
         $this->counter->inc(["op" => "noop"]);
     }


### PR DESCRIPTION
There was a typo on this class CurrentProccesesPerQueue so I replaced it with CurrentProcessesPerQueue.

Also added some more type hinting to different methods.